### PR TITLE
Download signing key is now a public method

### DIFF
--- a/src/Authorizer.php
+++ b/src/Authorizer.php
@@ -145,7 +145,7 @@ class Authorizer
      * @param string   $options  Options for the guzzle request
      * @return string
      */
-    protected static function downloadSigningKey($url, $options = [])
+    public static function downloadSigningKey($url, $options = [])
     {
         $client = new \GuzzleHttp\Client();
         $res = $client->get($url, $options);


### PR DESCRIPTION
It can be used outside of Authorizer
