### PR TITLE
Automatically encode/decode tokens to UTF8

### DIFF
--- a/src/Authorizer.php
+++ b/src/Authorizer.php
@@ -32,7 +32,7 @@ class Authorizer
      * @param string   $allowedResource
      * @param string   $authzgen         String with the format: {{certificate_url}};{{time_from}};{{time_to}}
      *                                   Time restrictions are unix timestamps, but may be omitted 
-     * @return string  $encryptedSecret
+     * @return string  $encryptedSecret  An utf8_encoded encrypted secret
      */
     public static function sign($allowedResource, $authzgen)
     {
@@ -50,20 +50,20 @@ class Authorizer
 
         openssl_public_encrypt($resourceSecret, $encryptedSecret, $publicKey);
 
-        return $encryptedSecret;
+        return utf8_encode($encryptedSecret);
     }
 
     /**
      * Decrypt an encrypted secret
      * 
-     * @param string   $encryptedSecret  An encrypted secret with the format:
+     * @param string   $encryptedSecret  An utf8_encoded encrypted secret with the format:
      *                                   {{resource}};{{time_from}};{{time_to}};{{hash}}
      *
      * @return string  $decryptedSecret  String with the format: {{time_from}};{{time_to}};{{checksum}}
      */
     public static function decrypt($encryptedSecret)
     {
-        openssl_private_decrypt($encryptedSecret, $decryptedSecret, self::getPrivateKey());
+        openssl_private_decrypt(utf8_decode($encryptedSecret), $decryptedSecret, self::getPrivateKey());
 
         return $decryptedSecret;
     }


### PR DESCRIPTION
It is not possible to do string operations like `json_encode` on the
output generated from `openssl_public_encrypt`, which makes POSTing the data a bit harder. The data currently would look similar to:

```
array(1) {
  [0]=>
  array(3) {
    ["filename"]=>
    string(13) "test.pdf"
    ["source"]=>
    string(79) "http://dms.legalthings.localhost/documents/5642663a96f687141d00002b.pdf?v=final"
    ["token"]=>
    string(128) "b��YG��XV
X�V}t�4�z0^<�|3 碚
gp�����������s5��yC(&�5b���/�](�z����E��{뱱��f���IHؙ��M6��{_�(�6-Ө,�������P"
  }
}
```

After `json_encode` you would get the output:
`boolean(false)`

If we, however, `utf8_encode` the output, data remains intact and transfering can be done much easier.
