### PR TITLE
Updated guzzle constraint to more flexible versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description" : "Authorizer for HTTP requests",
 	"license" : "MIT",
 	"require" : {
-		"guzzlehttp/guzzle": "^6.1"
+		"guzzlehttp/guzzle": "^5.0 || ^6.0"
 	},
 	"require-dev" : {
 		"codeception/codeception": "^2.1"


### PR DESCRIPTION
`\GuzzleHttp\Client()->get()` should work in earlier versions of guzzle aswell.